### PR TITLE
Bumped guzzlehttp/guzzle to 7.0 or higher

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
   "description": "A PHP library which implements the functionality of the Craftnet API",
   "version": "1.0.0",
   "require": {
-    "guzzlehttp/guzzle": "^6.3"
+    "guzzlehttp/guzzle": "^7.0"
   },
   "license": "MIT",
   "authors": [


### PR DESCRIPTION
I'm updating my plugins to support Craft 3.6 and that needs guzzlehttp/guzzle to be ^7.0 for PHP 8 compatibility. 
I tested creating a couple of licenses and view the reported and both seemed to work fine.